### PR TITLE
Prevent integration from loading in Hiero, HieroPlayer and NukeStudio.

### DIFF
--- a/pyblish_nuke/nuke_path/menu.py
+++ b/pyblish_nuke/nuke_path/menu.py
@@ -8,6 +8,11 @@ try:
     __import__("pyblish_nuke")
     __import__("pyblish")
 
+    # Do not load integration in NukeStudio, Hiero or HieroPlayer
+    invalid_args = ["--hiero", "--player", "--studio"]
+    if set(nuke.rawArgs) & set(invalid_args):
+        raise ImportError("pyblish-nuke only works in Nuke or NukeX.")
+
 except ImportError as e:
     nuke.tprint("pyblish: Could not load integration: %s " % e)
 


### PR DESCRIPTION
When publishing in NukeStudio or Hiero, the built-in plugins from pyblish-nuke gets loaded. This prevents it from happening.