### PR TITLE
Fix #43 (_show_no_gui not working)

### DIFF
--- a/pyblish_nuke/lib.py
+++ b/pyblish_nuke/lib.py
@@ -225,7 +225,7 @@ def publish():
     QtCore.QTimer.singleShot(10, publish_iter)
 
 
-def _show_no_gui():
+def _show_no_gui(_parent=None):
     """Popup with information about how to register a new GUI
 
     In the event of no GUI being registered or available,


### PR DESCRIPTION
Adressed #43. The function currently ignores the parent argument to be consistent with the other use of QMessageBox in the code, where also no parent is used.